### PR TITLE
feat: unify interpreter colors across booking and admin dashboard

### DIFF
--- a/app/api/admin-dashboard/jobs-total/[year]/route.ts
+++ b/app/api/admin-dashboard/jobs-total/[year]/route.ts
@@ -92,6 +92,15 @@ export async function GET(
     // Get all active interpreters for the year using consolidated utility
     const activeInterpreters = await fetchActiveInterpreters(prisma, dateRange);
     const { empCodeToName, interpreters } = createInterpreterMapping(activeInterpreters);
+    
+    // Create interpreter ID mapping for consistent colors
+    const interpreterIdMapping: Record<string, string> = {};
+    for (const interpreter of activeInterpreters) {
+      const name = empCodeToName.get(interpreter.empCode);
+      if (name) {
+        interpreterIdMapping[name] = interpreter.empCode;
+      }
+    }
 
     // Initialize month rows
     const rows = MONTH_LABELS.map<JobsRow>((m) => ({ month: m, total: 0 } as JobsRow));
@@ -128,6 +137,7 @@ export async function GET(
     const result = {
       months: MONTH_LABELS,
       interpreters,
+      interpreterIdMapping,
       totalJobsStack: rows,
       jobsFooter: { perInterpreter, grand, diff } as FooterByInterpreter,
       year: yearNum,

--- a/app/api/admin-dashboard/timejobs-total/[year]/route.ts
+++ b/app/api/admin-dashboard/timejobs-total/[year]/route.ts
@@ -92,6 +92,15 @@ export async function GET(
     // Get all active interpreters for the year using consolidated utility
     const activeInterpreters = await fetchActiveInterpreters(prisma, dateRange);
     const { empCodeToName, interpreters } = createInterpreterMapping(activeInterpreters);
+    
+    // Create interpreter ID mapping for consistent colors
+    const interpreterIdMapping: Record<string, string> = {};
+    for (const interpreter of activeInterpreters) {
+      const name = empCodeToName.get(interpreter.empCode);
+      if (name) {
+        interpreterIdMapping[name] = interpreter.empCode;
+      }
+    }
 
     // Helper to create zeroed objects matching the types
     const rows: HoursRow[] = MONTH_LABELS.map((m) => {
@@ -128,6 +137,7 @@ export async function GET(
     const result = {
       months: MONTH_LABELS,
       interpreters,
+      interpreterIdMapping,
       totalHoursLineMinutes: rows,
       hoursFooter: { perInterpreter, grand, diff } as FooterByInterpreter,
       year: yearNum,

--- a/app/api/admin-dashboard/typesjob-total/[year]/route.ts
+++ b/app/api/admin-dashboard/typesjob-total/[year]/route.ts
@@ -100,6 +100,15 @@ export async function GET(
     // Get all active interpreters for the year using consolidated utility
     const activeInterpreters = await fetchActiveInterpreters(prisma, dateRange);
     const { empCodeToName, interpreters } = createInterpreterMapping(activeInterpreters);
+    
+    // Create interpreter ID mapping for consistent colors
+    const interpreterIdMapping: Record<string, string> = {};
+    for (const interpreter of activeInterpreters) {
+      const name = empCodeToName.get(interpreter.empCode);
+      if (name) {
+        interpreterIdMapping[name] = interpreter.empCode;
+      }
+    }
 
     // prepare yearData 12 months with full MonthlyDataRowWithDR structure
     const yearData: MonthlyDataRowWithDR[] = MONTH_LABELS.map((m): MonthlyDataRowWithDR => {
@@ -165,6 +174,7 @@ export async function GET(
     const result = {
       months: MONTH_LABELS,
       interpreters,
+      interpreterIdMapping,
       year: yearNum,
       yearData,
       typesMGIFooter,

--- a/components/AdminDashboards/TotalAll/jobs-total-all.tsx
+++ b/components/AdminDashboards/TotalAll/jobs-total-all.tsx
@@ -127,7 +127,7 @@ export function JobsTab({ year, data: externalData }: JobsTabProps) {
 
   const interpreterColors = React.useMemo<Record<InterpreterName, string>>(() => {
     if (!currentData) return {} as Record<InterpreterName, string>;
-    return createInterpreterColorPalette(currentData.interpreters);
+    return createInterpreterColorPalette(currentData.interpreters, currentData.interpreterIdMapping);
   }, [currentData]);
 
   // Show 0 values when no data instead of returning null

--- a/components/AdminDashboards/TotalAll/timejobs-total-all.tsx
+++ b/components/AdminDashboards/TotalAll/timejobs-total-all.tsx
@@ -148,8 +148,8 @@ export function HoursTab({ year, data: externalData }: HoursTabProps) {
 
 
   const interpreterColors = React.useMemo<Map<InterpreterName, string>>(() => {
-    return getInterpreterColorPaletteAsMap(interpreters);
-  }, [interpreters]);
+    return getInterpreterColorPaletteAsMap(interpreters, currentData?.interpreterIdMapping);
+  }, [interpreters, currentData?.interpreterIdMapping]);
 
   // max minutes for Y axis
   const maxMinutes = React.useMemo(() => {

--- a/components/AdminDashboards/TotalMonth/deptjobs-total-month.tsx
+++ b/components/AdminDashboards/TotalMonth/deptjobs-total-month.tsx
@@ -161,8 +161,8 @@ export function DeptTab({ year, data: externalData, selectedMonth: propSelectedM
   const currentMonth = selectedMonth;
 
   const interpreterColors = React.useMemo<Record<InterpreterName, string>>(() => {
-    return createInterpreterColorPalette(interpreters);
-  }, [interpreters]);
+    return createInterpreterColorPalette(interpreters, currentData?.interpreterIdMapping);
+  }, [interpreters, currentData?.interpreterIdMapping]);
 
   const monthDeptData: SingleMonthDeptBar[] = React.useMemo(() => {
     if (!selectedMonth) return [];

--- a/components/AdminDashboards/TotalMonth/jobs-total-month.tsx
+++ b/components/AdminDashboards/TotalMonth/jobs-total-month.tsx
@@ -129,7 +129,7 @@ export function JobsTab({ year, data: externalData, selectedMonth }: JobsTabProp
 
   const interpreterColors = React.useMemo<Record<InterpreterName, string>>(() => {
     if (!currentData) return {} as Record<InterpreterName, string>;
-    return createInterpreterColorPalette(currentData.interpreters);
+    return createInterpreterColorPalette(currentData.interpreters, currentData.interpreterIdMapping);
   }, [currentData]);
 
   // Show 0 values when no data instead of returning null

--- a/components/AdminDashboards/TotalMonth/mtgtypejobs-total-month.tsx
+++ b/components/AdminDashboards/TotalMonth/mtgtypejobs-total-month.tsx
@@ -229,8 +229,8 @@ export function TypesTab({ year, data: externalData, selectedMonth: propSelected
 
   // color palette
   const interpreterColors = React.useMemo<Record<InterpreterName, string>>(() => {
-    return createInterpreterColorPalette(interpreters);
-  }, [interpreters]);
+    return createInterpreterColorPalette(interpreters, currentData?.interpreterIdMapping);
+  }, [interpreters, currentData?.interpreterIdMapping]);
 
   // ===== Chart dataset  =====
   const monthBarData: SingleMonthBar[] = React.useMemo(() => {

--- a/components/AdminDashboards/TotalMonth/timejobs-total-month.tsx
+++ b/components/AdminDashboards/TotalMonth/timejobs-total-month.tsx
@@ -160,8 +160,8 @@ export function HoursTab({ year, data: externalData, selectedMonth }: HoursTabPr
   }, [selectedMonth, currentData]);
 
   const interpreterColors = React.useMemo<Map<InterpreterName, string>>(() => {
-    return getInterpreterColorPaletteAsMap(interpreters);
-  }, [interpreters]);
+    return getInterpreterColorPaletteAsMap(interpreters, currentData?.interpreterIdMapping);
+  }, [interpreters, currentData?.interpreterIdMapping]);
 
 
   // Filter data for selected month only

--- a/types/admin-dashboard.ts
+++ b/types/admin-dashboard.ts
@@ -85,6 +85,7 @@ export interface AssignmentLogsApiResponse {
 export interface JobsApiResponse {
   months: MonthName[];
   interpreters: InterpreterName[];
+  interpreterIdMapping?: Record<string, string>; // interpreter name -> interpreter ID
   totalJobsStack: JobsRow[];
   jobsFooter: FooterByInterpreter;
   year: number;
@@ -94,6 +95,7 @@ export interface JobsApiResponse {
 export interface HoursApiResponse {
   months: MonthName[];
   interpreters: InterpreterName[];
+  interpreterIdMapping?: Record<string, string>; // interpreter name -> interpreter ID
   totalHoursLineMinutes: HoursRow[];
   hoursFooter: FooterByInterpreter;
   year: number;
@@ -103,6 +105,7 @@ export interface HoursApiResponse {
 export interface DepartmentsApiResponse {
   months: MonthName[];
   interpreters: InterpreterName[];
+  interpreterIdMapping?: Record<string, string>; // interpreter name -> interpreter ID
   departments: OwnerGroup[];
   year: number;
   yearData: MonthlyDataRow[];
@@ -117,6 +120,7 @@ export interface MonthlyDataRowWithDR extends MonthlyDataRow {
 export interface TypesApiResponse {
   months: MonthName[];
   interpreters: InterpreterName[];
+  interpreterIdMapping?: Record<string, string>; // interpreter name -> interpreter ID
   year: number;
   yearData: MonthlyDataRowWithDR[];
   typesMGIFooter: FooterByInterpreter;


### PR DESCRIPTION
- Unified interpreter color system between booking calendar and admin dashboard
- Added interpreterIdMapping to all admin dashboard APIs for consistent ID-based colors
- Updated admin dashboard components to use unified color system
- Fixed MeetingType definitions (Augent -> Urgent, removed PDR)
- Replaced local utility functions with standard createZeroMeetingTypes/createZeroOwnerGroups
- Added interpreterIdMapping to JobsApiResponse, HoursApiResponse, TypesApiResponse, DepartmentsApiResponse
- Ensures same interpreter has same color across all pages for better UX

Breaking changes: None (interpreterIdMapping is optional for backward compatibility)